### PR TITLE
chore: upgrade Node 22 runtime & bump GitHub Actions versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
       MESSAGING_PK: ${{ secrets.MESSAGING_PK }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: '22'
 

--- a/.github/workflows/firebase-hosting.yml
+++ b/.github/workflows/firebase-hosting.yml
@@ -17,7 +17,7 @@ jobs:
     env:
       RUN_ID:  ${{ github.event.workflow_run.id }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Test run it
         run: echo "Test run it  $RUN_ID"

--- a/functions/package.json
+++ b/functions/package.json
@@ -11,7 +11,7 @@
     "logs": "firebase functions:log"
   },
   "engines": {
-    "node": "20"
+    "node": "22"
   },
   "main": "lib/functions/src/index.js",
   "dependencies": {


### PR DESCRIPTION
## Summary
- `functions/package.json` — `"node": "20"` → `"22"` (Firebase gen2 fully supports Node 22; Node 20 EOL is 2026-04-30)
- `ci.yml` — `actions/checkout@v2` → `v4`, `actions/setup-node@v2` → `v4`
- `firebase-hosting.yml` — `actions/checkout@v2` → `v4`

Resolves two deprecation warnings:
1. Firebase deploy: _"Runtime Node.js 20 will be deprecated on 2026-04-30"_
2. GitHub Actions: _"Node.js 20 actions are deprecated"_ (checkout, setup-node)

## Test Plan
- [ ] CI passes on Node 22
- [ ] Firebase deploy no longer shows Node 20 deprecation warning
- [ ] Firebase deploy no longer shows GitHub Actions Node 20 deprecation warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)