### PR TITLE
fix: cascade delete related documents on portfolio deletion

### DIFF
--- a/docs/superpowers/plans/2026-04-03-portfolio-target.md
+++ b/docs/superpowers/plans/2026-04-03-portfolio-target.md
@@ -1,0 +1,638 @@
+# Portfolio Target Feature Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a milestone strip section to the dashboard showing progress toward a user-defined portfolio target value.
+
+**Architecture:** Expose `target` data from the existing `usePortfolioKpis` composable, create a new `PortfolioTarget.vue` component that renders a milestone strip, and wire it into `Dashboard.vue` conditionally. No data layer changes — `Portfolio.target`, the transformer calculation, and the dialog input all already exist.
+
+**Tech Stack:** Vue 3 (Options API, `defineComponent`), Quasar 2, TypeScript, Pinia, Vite/Quasar aliases (`src/`, `app/`, `components/`, `stores/`)
+
+---
+
+## File Map
+
+| File | Action |
+|---|---|
+| `src/components/composables/usePortfolioKpis.ts` | Modify — expose `target` computed |
+| `src/components/dashboard/PortfolioTarget.vue` | **Create** — milestone strip component |
+| `src/pages/Dashboard.vue` | Modify — import + render `PortfolioTarget` conditionally |
+
+---
+
+### Task 1: Expose `target` from `usePortfolioKpis`
+
+**Files:**
+- Modify: `src/components/composables/usePortfolioKpis.ts`
+
+**Context:** The composable currently returns `{ kpis }`. `portfoliosTransformer.portfolioKPIS(portfolio)` already computes `target.percentage = (currentValue + cashFlow) / portfolio.target`. We need to also expose a `target` ref that is `null` when no target is set.
+
+The full current file content of `src/components/composables/usePortfolioKpis.ts`:
+```ts
+import { computed } from 'vue';
+import { portfoliosTransformer } from 'app/shared/transformers';
+import { usePortfolioStore } from 'src/stores/portfolios';
+import { useI18n } from 'vue-i18n';
+
+export const usePortfolioKpis = () => {
+  const $t = useI18n().t;
+  const portfolioStore = usePortfolioStore();
+
+  const kpis = computed(() => {
+    const portfolio = portfolioStore.selectedPortfolioWithHoldings;
+    if (!portfolio) {
+      return [];
+    }
+
+    const portfolioKpis = portfoliosTransformer.portfolioKPIS(portfolio);
+
+    return [
+      {
+        id: 'balance',
+        title: $t('dashboard.kpis.value'),
+        value: portfolio.currentValue ?? 0,
+        icon: 'balance',
+        subtitle: {
+          text: 'invested',
+          value: portfolio.invested ?? 0,
+        },
+      },
+      {
+        id: 'profits',
+        title: $t('dashboard.kpis.profit'),
+        value: portfolioKpis.profit.value ?? 0,
+        valuePercentage: portfolioKpis.profit.percentage,
+        showValueSign: true,
+        tooltip: {
+          capital: portfolio.capitalGains ?? 0,
+          realized: portfoliosTransformer.realizedGains(portfolio),
+          fees: (portfolio.fees ?? 0) * -1,
+        },
+        icon: 'trending_up',
+        subtitle: {
+          text: 'daily',
+          value: portfolioKpis.dailyChange.value,
+          percentage: portfolioKpis.dailyChange.percentage,
+          className:
+            portfolioKpis.dailyChange.value >= 0
+              ? 'text-green-5'
+              : 'text-red-5',
+        },
+      },
+      {
+        id: 'cashflow',
+        title: $t('dashboard.kpis.cash_flow'),
+        value: portfoliosTransformer.cashFlow(portfolio),
+        icon: 'account_balance',
+        subtitle: {
+          text: 'deposited',
+          value: portfoliosTransformer.depositsValue(portfolio),
+        },
+      },
+    ];
+  });
+
+  return { kpis };
+};
+```
+
+- [ ] **Step 1: Write a failing test**
+
+This project has no unit test framework set up for Vue composables, so we validate via TypeScript compilation and runtime. Instead, write a type-level test by verifying the return shape — add a test assertion block at the bottom of the file temporarily, then remove it. Skip to Step 2.
+
+- [ ] **Step 2: Implement the `target` computed**
+
+Replace the entire file content of `src/components/composables/usePortfolioKpis.ts` with:
+
+```ts
+import { computed } from 'vue';
+import { portfoliosTransformer } from 'app/shared/transformers';
+import { usePortfolioStore } from 'src/stores/portfolios';
+import { useI18n } from 'vue-i18n';
+
+export const usePortfolioKpis = () => {
+  const $t = useI18n().t;
+  const portfolioStore = usePortfolioStore();
+
+  const kpis = computed(() => {
+    const portfolio = portfolioStore.selectedPortfolioWithHoldings;
+    if (!portfolio) {
+      return [];
+    }
+
+    const portfolioKpis = portfoliosTransformer.portfolioKPIS(portfolio);
+
+    return [
+      {
+        id: 'balance',
+        title: $t('dashboard.kpis.value'),
+        value: portfolio.currentValue ?? 0,
+        icon: 'balance',
+        subtitle: {
+          text: 'invested',
+          value: portfolio.invested ?? 0,
+        },
+      },
+      {
+        id: 'profits',
+        title: $t('dashboard.kpis.profit'),
+        value: portfolioKpis.profit.value ?? 0,
+        valuePercentage: portfolioKpis.profit.percentage,
+        showValueSign: true,
+        tooltip: {
+          capital: portfolio.capitalGains ?? 0,
+          realized: portfoliosTransformer.realizedGains(portfolio),
+          fees: (portfolio.fees ?? 0) * -1,
+        },
+        icon: 'trending_up',
+        subtitle: {
+          text: 'daily',
+          value: portfolioKpis.dailyChange.value,
+          percentage: portfolioKpis.dailyChange.percentage,
+          className:
+            portfolioKpis.dailyChange.value >= 0
+              ? 'text-green-5'
+              : 'text-red-5',
+        },
+      },
+      {
+        id: 'cashflow',
+        title: $t('dashboard.kpis.cash_flow'),
+        value: portfoliosTransformer.cashFlow(portfolio),
+        icon: 'account_balance',
+        subtitle: {
+          text: 'deposited',
+          value: portfoliosTransformer.depositsValue(portfolio),
+        },
+      },
+    ];
+  });
+
+  const target = computed(() => {
+    const portfolio = portfolioStore.selectedPortfolioWithHoldings;
+    if (!portfolio?.target) return null;
+
+    const portfolioKpis = portfoliosTransformer.portfolioKPIS(portfolio);
+    const cashFlow = portfoliosTransformer.cashFlow(portfolio);
+
+    return {
+      targetAmount: portfolio.target,
+      currentValue: portfolio.currentValue + cashFlow,
+      percentage: portfolioKpis.target.percentage,
+    };
+  });
+
+  return { kpis, target };
+};
+```
+
+- [ ] **Step 3: Verify TypeScript compiles**
+
+```bash
+cd /Users/odedgo/Development/portfolio-tracker && npx vue-tsc --noEmit 2>&1 | head -30
+```
+
+Expected: no errors related to `usePortfolioKpis`. If you see errors about missing properties, check the `portfoliosTransformer.portfolioKPIS` return shape in `shared/transformers/portfolios.ts` — it returns `{ target: { value, percentage }, profit, dailyChange }`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/composables/usePortfolioKpis.ts
+git commit -m "feat: expose target data from usePortfolioKpis composable"
+```
+
+---
+
+### Task 2: Create `PortfolioTarget.vue` milestone strip component
+
+**Files:**
+- Create: `src/components/dashboard/PortfolioTarget.vue`
+
+**Context:** This component receives `currentValue`, `targetAmount`, and `percentage` as props and renders:
+1. A header line: "Goal: $X"
+2. A horizontal track bar (filled up to `min(percentage, 1) * 100%`)
+3. Four milestone dots at 25%, 50%, 75%, 100% — each labeled with the abbreviated dollar value at that milestone
+4. A position bubble at `min(percentage, 1) * 100%` showing current value + percentage
+5. When `percentage >= 1`: bar is fully filled, bubble replaced with "Target reached! 🎯"
+
+The component follows the existing Options API pattern (`defineComponent`) used throughout the codebase. Use Quasar's `useQuasar` for `$n` number formatting, or use `useI18n` — actually, looking at the codebase, `$n` is available as a template global from Quasar's i18n plugin. Use `$n(val, 'decimal')` in templates for full values. For abbreviated values in the milestone labels, use a local `abbreviate()` helper.
+
+- [ ] **Step 1: Create the file**
+
+Create `src/components/dashboard/PortfolioTarget.vue` with this full content:
+
+```vue
+<template>
+  <q-card flat class="portfolio-target q-pa-md">
+    <div class="flex items-center justify-between q-mb-sm">
+      <span class="text-subtitle1 text-grey-7">
+        Goal: {{ $n(targetAmount, 'decimal') }}
+      </span>
+      <span v-if="isReached" class="text-positive text-subtitle2">
+        <q-icon name="emoji_events" size="sm" class="q-mr-xs" />
+        Target reached!
+      </span>
+      <span v-else class="text-subtitle2 text-grey-6">
+        {{ $n(currentValue, 'decimal') }} &middot;
+        {{ (Math.min(percentage, 1) * 100).toFixed(1) }}%
+      </span>
+    </div>
+
+    <div class="target-track-wrapper">
+      <!-- Filled progress bar -->
+      <div class="target-track">
+        <div
+          class="target-track__fill bg-primary"
+          :style="{ width: fillWidth }"
+        />
+      </div>
+
+      <!-- Milestone dots + labels -->
+      <div
+        v-for="milestone in milestones"
+        :key="milestone.percentage"
+        class="target-milestone"
+        :style="{ left: milestone.percentage * 100 + '%' }"
+      >
+        <div
+          class="target-milestone__dot"
+          :class="percentage >= milestone.percentage ? 'bg-primary' : 'bg-grey-4'"
+        />
+        <span class="target-milestone__label text-caption text-grey-6">
+          {{ abbreviate(milestone.value) }}
+        </span>
+      </div>
+
+      <!-- Current position indicator -->
+      <div
+        v-if="!isReached"
+        class="target-position"
+        :style="{ left: fillWidth }"
+      >
+        <div class="target-position__dot bg-primary" />
+      </div>
+    </div>
+  </q-card>
+</template>
+
+<script lang="ts">
+import { computed, defineComponent } from 'vue';
+
+export default defineComponent({
+  name: 'PortfolioTarget',
+
+  props: {
+    currentValue: {
+      type: Number,
+      required: true,
+    },
+    targetAmount: {
+      type: Number,
+      required: true,
+    },
+    percentage: {
+      type: Number,
+      required: true,
+    },
+  },
+
+  setup(props) {
+    const isReached = computed(() => props.percentage >= 1);
+
+    const fillWidth = computed(
+      () => `${Math.min(props.percentage, 1) * 100}%`
+    );
+
+    const milestones = computed(() =>
+      [0.25, 0.5, 0.75, 1].map((p) => ({
+        percentage: p,
+        value: props.targetAmount * p,
+      }))
+    );
+
+    const abbreviate = (val: number): string => {
+      if (val >= 1_000_000) return `$${(val / 1_000_000).toFixed(1)}M`;
+      if (val >= 1_000) return `$${(val / 1_000).toFixed(0)}k`;
+      return `$${val}`;
+    };
+
+    return {
+      isReached,
+      fillWidth,
+      milestones,
+      abbreviate,
+    };
+  },
+});
+</script>
+
+<style lang="scss" scoped>
+.portfolio-target {
+  width: 100%;
+}
+
+.target-track-wrapper {
+  position: relative;
+  padding-bottom: 24px; // space for milestone labels below the track
+  margin: 0 8px; // slight indent so 100% milestone dot isn't clipped
+}
+
+.target-track {
+  height: 8px;
+  background: $grey-3;
+  border-radius: 4px;
+  overflow: hidden;
+  position: relative;
+}
+
+.target-track__fill {
+  height: 100%;
+  border-radius: 4px;
+  transition: width 0.4s ease;
+}
+
+.target-milestone {
+  position: absolute;
+  top: -4px; // align dot center with track center
+  transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.target-milestone__dot {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 2px solid white;
+  box-shadow: 0 0 0 1px $grey-4;
+}
+
+.target-milestone__label {
+  margin-top: 4px;
+  white-space: nowrap;
+}
+
+.target-position {
+  position: absolute;
+  top: -6px;
+  transform: translateX(-50%);
+}
+
+.target-position__dot {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  border: 3px solid white;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+}
+</style>
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+```bash
+cd /Users/odedgo/Development/portfolio-tracker && npx vue-tsc --noEmit 2>&1 | head -30
+```
+
+Expected: no new errors. If you see `$n is not defined` — it's a Quasar template global, not an import. It's injected via the i18n boot plugin. No fix needed in the component.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/dashboard/PortfolioTarget.vue
+git commit -m "feat: add PortfolioTarget milestone strip component"
+```
+
+---
+
+### Task 3: Wire `PortfolioTarget` into `Dashboard.vue`
+
+**Files:**
+- Modify: `src/pages/Dashboard.vue`
+
+**Context:** The dashboard uses a CSS grid. We need to:
+1. Import and register `PortfolioTarget`
+2. Expose `target` from `usePortfolioKpis` in `setup()`
+3. Add the component to the template with `v-if="target"`
+4. Add a `target` grid area between the `kpi` row and `donut/heatmap` row
+
+The full current file content of `src/pages/Dashboard.vue`:
+```vue
+<template>
+  <q-page class="row justify-center q-pa-md">
+    <div class="col-10 dashboard-grid">
+      <p class="text-h5 text-grey-7 dashboard-title">
+        Portfolio's / {{ viewPortfolio?.title }}
+      </p>
+      <div v-for="(kpi, index) in kpis" :key="kpi.title" class="col">
+        <dashboard-kpi v-bind="kpi" :class="`dashboard-kpi-${index}`" />
+      </div>
+      <holdings-donut class="col-8 dashboard-holdings-donut q-mt-lg" />
+      <portfolio-heat-map class="dashboard-portfolio-heat-map" />
+      <daily-movers class="dashboard-daily-movers" />
+      <portfolio-insights class="dashboard-portfolio-insights" />
+    </div>
+    <sticky-quick-add />
+  </q-page>
+</template>
+
+<script lang="ts">
+import { computed, defineComponent } from 'vue';
+import { usePortfolioStore } from 'stores/portfolios';
+import { usePortfolioKpis } from 'src/components/composables/usePortfolioKpis';
+import DashboardKpi from 'components/dashboard/DashboardKPI.vue';
+import HoldingsDonut from 'components/dashboard/HoldingsDonut.vue';
+import PortfolioHeatMap from 'components/dashboard/PortfolioHeatMap.vue';
+import PortfolioInsights from 'components/dashboard/PortfolioInsights.vue';
+import DailyMovers from 'components/dashboard/DailyMovers.vue';
+import StickyQuickAdd from 'components/dashboard/StickyQuickAdd.vue';
+
+export default defineComponent({
+  name: 'DashboardPage',
+  components: {
+    StickyQuickAdd,
+    DailyMovers,
+    PortfolioHeatMap,
+    HoldingsDonut,
+    DashboardKpi,
+    PortfolioInsights,
+  },
+  setup() {
+    const portfolioStore = usePortfolioStore();
+    const { kpis } = usePortfolioKpis();
+
+    const viewPortfolio = computed(
+      () => portfolioStore.selectedPortfolioWithHoldings
+    );
+
+    return {
+      viewPortfolio,
+      kpis,
+    };
+  },
+});
+</script>
+
+<style lang="scss">
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-template-rows: repeat(4, auto);
+  grid-column-gap: 16px;
+  grid-template-areas:
+    'title title title'
+    'kpi kpi kpi'
+    'donut donut heatmap'
+    'daily_movers daily_movers daily_movers'
+    'insights insights insights';
+}
+
+.dashboard-quick-add {
+  height: 40px;
+}
+
+.dashboard-title {
+  grid-area: title;
+}
+.dashboard-holdings-donut {
+  grid-area: donut;
+}
+
+.dashboard-portfolio-heat-map {
+  grid-area: heatmap;
+}
+.dashboard-daily-movers {
+  grid-area: daily_movers;
+}
+.dashboard-portfolio-insights {
+  grid-area: insights;
+}
+</style>
+```
+
+- [ ] **Step 1: Replace the entire file**
+
+Replace `src/pages/Dashboard.vue` with:
+
+```vue
+<template>
+  <q-page class="row justify-center q-pa-md">
+    <div class="col-10 dashboard-grid">
+      <p class="text-h5 text-grey-7 dashboard-title">
+        Portfolio's / {{ viewPortfolio?.title }}
+      </p>
+      <div v-for="(kpi, index) in kpis" :key="kpi.title" class="col">
+        <dashboard-kpi v-bind="kpi" :class="`dashboard-kpi-${index}`" />
+      </div>
+      <portfolio-target
+        v-if="target"
+        class="dashboard-portfolio-target"
+        :current-value="target.currentValue"
+        :target-amount="target.targetAmount"
+        :percentage="target.percentage"
+      />
+      <holdings-donut class="col-8 dashboard-holdings-donut q-mt-lg" />
+      <portfolio-heat-map class="dashboard-portfolio-heat-map" />
+      <daily-movers class="dashboard-daily-movers" />
+      <portfolio-insights class="dashboard-portfolio-insights" />
+    </div>
+    <sticky-quick-add />
+  </q-page>
+</template>
+
+<script lang="ts">
+import { computed, defineComponent } from 'vue';
+import { usePortfolioStore } from 'stores/portfolios';
+import { usePortfolioKpis } from 'src/components/composables/usePortfolioKpis';
+import DashboardKpi from 'components/dashboard/DashboardKPI.vue';
+import HoldingsDonut from 'components/dashboard/HoldingsDonut.vue';
+import PortfolioHeatMap from 'components/dashboard/PortfolioHeatMap.vue';
+import PortfolioInsights from 'components/dashboard/PortfolioInsights.vue';
+import DailyMovers from 'components/dashboard/DailyMovers.vue';
+import StickyQuickAdd from 'components/dashboard/StickyQuickAdd.vue';
+import PortfolioTarget from 'components/dashboard/PortfolioTarget.vue';
+
+export default defineComponent({
+  name: 'DashboardPage',
+  components: {
+    StickyQuickAdd,
+    DailyMovers,
+    PortfolioHeatMap,
+    HoldingsDonut,
+    DashboardKpi,
+    PortfolioInsights,
+    PortfolioTarget,
+  },
+  setup() {
+    const portfolioStore = usePortfolioStore();
+    const { kpis, target } = usePortfolioKpis();
+
+    const viewPortfolio = computed(
+      () => portfolioStore.selectedPortfolioWithHoldings
+    );
+
+    return {
+      viewPortfolio,
+      kpis,
+      target,
+    };
+  },
+});
+</script>
+
+<style lang="scss">
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-template-rows: repeat(5, auto);
+  grid-column-gap: 16px;
+  grid-template-areas:
+    'title title title'
+    'kpi kpi kpi'
+    'target target target'
+    'donut donut heatmap'
+    'daily_movers daily_movers daily_movers'
+    'insights insights insights';
+}
+
+.dashboard-quick-add {
+  height: 40px;
+}
+
+.dashboard-title {
+  grid-area: title;
+}
+.dashboard-portfolio-target {
+  grid-area: target;
+}
+.dashboard-holdings-donut {
+  grid-area: donut;
+}
+
+.dashboard-portfolio-heat-map {
+  grid-area: heatmap;
+}
+.dashboard-daily-movers {
+  grid-area: daily_movers;
+}
+.dashboard-portfolio-insights {
+  grid-area: insights;
+}
+</style>
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+```bash
+cd /Users/odedgo/Development/portfolio-tracker && npx vue-tsc --noEmit 2>&1 | head -30
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/pages/Dashboard.vue
+git commit -m "feat: render PortfolioTarget section on dashboard when target is set"
+```

--- a/docs/superpowers/specs/2026-04-03-portfolio-target-design.md
+++ b/docs/superpowers/specs/2026-04-03-portfolio-target-design.md
@@ -1,0 +1,162 @@
+# Portfolio Target Feature — Design Spec
+
+**Date:** 2026-04-03
+**Issue:** #21
+**Status:** Approved
+
+---
+
+## Goal
+
+Allow users to set a financial target on a portfolio and see progress toward it on the dashboard as a milestone strip — visible only when a target is configured.
+
+---
+
+## What Already Exists
+
+- `Portfolio.target: number` — already in the type and Firestore
+- `PortfolioDialog.vue` — already has the `target` input field (no changes needed)
+- `portfoliosTransformer.portfolioKPIS()` — already computes `target.value` and `target.percentage = (currentValue + cashFlow) / target`
+
+Nothing in the data layer needs to change. This is purely a UI feature.
+
+---
+
+## Architecture
+
+Three files touched, one new file created:
+
+| File | Change |
+|---|---|
+| `src/components/composables/usePortfolioKpis.ts` | Expose `target` data from the transformer |
+| `src/components/dashboard/PortfolioTarget.vue` | **New** — milestone strip component |
+| `src/pages/Dashboard.vue` | Import and render `PortfolioTarget` conditionally |
+
+---
+
+## Component: `usePortfolioKpis` change
+
+Add a `target` computed alongside `kpis`:
+
+```ts
+const target = computed(() => {
+  const portfolio = portfolioStore.selectedPortfolioWithHoldings;
+  if (!portfolio?.target) return null;
+
+  const kpis = portfoliosTransformer.portfolioKPIS(portfolio);
+  const cashFlow = portfoliosTransformer.cashFlow(portfolio);
+  const currentValue = portfolio.currentValue + cashFlow;
+
+  return {
+    targetAmount: portfolio.target,               // the goal ($500k)
+    currentValue,                                  // current value + cashFlow
+    percentage: kpis.target.percentage,            // currentValue / targetAmount
+  };
+});
+
+return { kpis, target };
+```
+
+Returns `null` when no target is set (portfolio.target is 0 or falsy). Consumers use this to conditionally render the section.
+
+---
+
+## Component: `PortfolioTarget.vue`
+
+**Props:**
+```ts
+props: {
+  currentValue: number,  // currentValue + cashFlow
+  targetAmount: number,  // target goal amount
+  percentage: number,    // currentValue / targetAmount, can exceed 1.0
+}
+```
+
+**Milestone strip layout:**
+
+```
+Goal: $500,000
+
+  ●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━●
+  |          |          |          |          |
+ $125k      $250k      $375k      $500k
+
+               ▲
+           $310k · 62%
+```
+
+- Track: a horizontal bar (`q-linear-progress` or plain `div`) with `primary` color fill, clamped at 100%
+- **Milestone dots:** 4 fixed markers at 25%, 50%, 75%, 100% — absolutely positioned on the track using `left: X%`. Each shows the dollar value (formatted with `$n` using `'decimal'` format, abbreviated for readability — e.g. `$125k`)
+- **Current position bubble:** absolutely positioned at `min(percentage, 1) * 100%`, shows `$currentValue · XX%`. Uses a small Quasar chip or styled `span`
+- **Over-target state:** when `percentage >= 1`, clamp bubble to 100%, show label "Target reached!" with a trophy/flag icon instead of value bubble
+- **Header:** "Goal: $500,000" in `text-subtitle1 text-grey-7` above the strip (uses `$n(targetAmount, 'decimal')` for formatting)
+
+**Value abbreviation helper** (local to component):
+```ts
+const abbreviate = (val: number) => {
+  if (val >= 1_000_000) return `$${(val / 1_000_000).toFixed(1)}M`;
+  if (val >= 1_000) return `$${(val / 1_000).toFixed(0)}k`;
+  return `$${val}`;
+};
+```
+
+**Milestone values:** computed from `targetAmount` prop:
+```ts
+const milestones = computed(() => [0.25, 0.5, 0.75, 1].map(p => ({
+  percentage: p,
+  value: props.targetAmount * p,
+})));
+```
+
+---
+
+## Dashboard.vue integration
+
+Add a new grid area `target` between the KPI row and the donut/heatmap row. Only rendered when `target` is non-null:
+
+```html
+<portfolio-target
+  v-if="target"
+  class="dashboard-portfolio-target"
+  :current-value="target.currentValue"
+  :target-amount="target.targetAmount"
+  :percentage="target.percentage"
+/>
+```
+
+Grid area added:
+```scss
+grid-template-areas:
+  'title title title'
+  'kpi kpi kpi'
+  'target target target'   // new row, only occupies space when rendered
+  'donut donut heatmap'
+  'daily_movers daily_movers daily_movers'
+  'insights insights insights';
+
+.dashboard-portfolio-target {
+  grid-area: target;
+}
+```
+
+Since `v-if` removes the element from the DOM entirely, no empty space appears when no target is set.
+
+---
+
+## Edge Cases
+
+| Scenario | Behavior |
+|---|---|
+| `portfolio.target` is 0 or unset | `target` computed returns `null`, section hidden |
+| `percentage > 1` (over target) | Bar clamped at 100%, bubble replaced with "Target reached!" label |
+| `percentage` is `NaN` (target=0 and somehow reached) | Guard in composable: return `null` if `!portfolio.target` |
+| Negative cashFlow (over-invested) | Formula handles it: `(currentValue + cashFlow) / target` may be lower, renders correctly |
+
+---
+
+## What Is NOT Changing
+
+- `PortfolioDialog.vue` — target input already exists, no changes
+- `portfoliosTransformer.portfolioKPIS()` — already computes target correctly, no changes
+- Firestore / backend — no schema changes needed
+- No new translations needed beyond what already exists (`portfolios.target`, `portfolios.target_explain`)

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -8,6 +8,7 @@ import { migrations } from './migrations';
 import { alertsHandler } from './alerts';
 import { getPortfoliosContext } from './utils/getPortfoliosContext';
 import { isTradingDay } from './utils/isTradingDay';
+import { onPortfolioDeleted } from './portfolioCleanup';
 
 admin.initializeApp();
 
@@ -72,6 +73,8 @@ export const portfolioScheduler = onSchedule(
     return;
   }
 );
+
+export { onPortfolioDeleted };
 
 export const notificationsScheduler = onSchedule(
   {

--- a/functions/src/portfolioCleanup.ts
+++ b/functions/src/portfolioCleanup.ts
@@ -1,0 +1,47 @@
+import { onDocumentDeleted } from 'firebase-functions/v2/firestore';
+import * as logger from 'firebase-functions/logger';
+import { getFirestore } from 'firebase-admin/firestore';
+import { AppCollectionsNames } from '../../shared/types';
+import { deleteDocumentsByPortfolioId } from './utils/getCollection';
+
+const PORTFOLIO_DEPENDENT_COLLECTIONS: AppCollectionsNames[] = [
+  'holdings',
+  'transactions',
+  'portfolioHistory',
+  'insights',
+  'alerts',
+  'notifications',
+];
+
+export const onPortfolioDeleted = onDocumentDeleted(
+  'portfolios/{portfolioId}',
+  async (event) => {
+    const portfolioId = event.params.portfolioId;
+    const db = getFirestore();
+
+    logger.info('Portfolio deleted, starting cascade cleanup', { portfolioId });
+
+    const results = await Promise.all(
+      PORTFOLIO_DEPENDENT_COLLECTIONS.map(async (collection) => {
+        const deleted = await deleteDocumentsByPortfolioId(
+          db,
+          collection,
+          portfolioId
+        );
+        logger.info(`Cleaned up ${deleted} docs from ${collection}`, {
+          portfolioId,
+          collection,
+          deleted,
+        });
+        return { collection, deleted };
+      })
+    );
+
+    const totalDeleted = results.reduce((sum, r) => sum + r.deleted, 0);
+    logger.info('Portfolio cascade cleanup complete', {
+      portfolioId,
+      totalDeleted,
+      breakdown: results,
+    });
+  }
+);

--- a/functions/src/utils/getCollection.ts
+++ b/functions/src/utils/getCollection.ts
@@ -37,3 +37,29 @@ export const updateDocuments = async <Entity extends { id: string }>(
     await collectionRef.doc(entity.id).update(entity);
   });
 };
+
+export const deleteDocumentsByPortfolioId = async (
+  db: FirebaseFirestore.Firestore,
+  collection: AppCollectionsNames,
+  portfolioId: string
+): Promise<number> => {
+  const snap = await db
+    .collection(collection)
+    .where('portfolioId', '==', portfolioId)
+    .get();
+
+  if (snap.empty) return 0;
+
+  const BATCH_SIZE = 499;
+  const docs = snap.docs;
+  let deleted = 0;
+
+  for (let i = 0; i < docs.length; i += BATCH_SIZE) {
+    const batch = db.batch();
+    docs.slice(i, i + BATCH_SIZE).forEach((doc) => batch.delete(doc.ref));
+    await batch.commit();
+    deleted += Math.min(BATCH_SIZE, docs.length - i);
+  }
+
+  return deleted;
+};


### PR DESCRIPTION
## Summary
- Adds `deleteDocumentsByPortfolioId` batch-delete utility in `functions/src/utils/getCollection.ts` — handles >500 docs via chunked batches (499 ops/batch)
- Adds `onPortfolioDeleted` gen2 Firestore trigger in `functions/src/portfolioCleanup.ts` — cascade-deletes holdings, transactions, portfolioHistory, insights, alerts, and notifications when a portfolio document is deleted
- Registers and exports the trigger in `functions/src/index.ts`

Closes #60

## Test Plan
- [ ] Start Firebase emulators (`firebase emulators:start --only firestore,functions`)
- [ ] Create a portfolio with related documents in each affected collection
- [ ] Delete the portfolio document and verify all related docs are removed
- [ ] Check function logs for `Portfolio cascade cleanup complete` summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)