### PR TITLE
fix: analytics chart crash when selecting period beyond 1 year

### DIFF
--- a/src/components/analytics/AnalyticsGraphs.vue
+++ b/src/components/analytics/AnalyticsGraphs.vue
@@ -5,12 +5,14 @@
     :title="$t('charts.portfolio_value')"
     :show-transactions-markers="true"
     :benchmarkData="benchmarkData"
+    @update:apiRange="onApiRangeChange"
   />
 
   <portfolio-performance
     :title="$t('charts.portfolio_performance')"
     mode="percentage"
     :benchmarkData="benchmarkData"
+    @update:apiRange="onApiRangeChange"
   />
 
   <portfolio-monthly-yield :benchmark-data="benchmarkData" />
@@ -35,12 +37,21 @@ export default defineComponent({
   },
   setup() {
     const benchmarkData = ref<StockCharData[]>([]);
+    const selectedTickers = ref<string[]>([]);
+    const currentApiRange = ref<string | undefined>(undefined);
 
     const { emitLoadingTask } = useLoadingStore();
 
-    const setBenchmarkData = async (tickers: string[]) => {
+    const fetchBenchmarkData = async (
+      tickers: string[],
+      range?: string
+    ) => {
       await emitLoadingTask(async () => {
-        const chartQuotesResponse = await getQuotesChartData(tickers);
+        const chartQuotesResponse = await getQuotesChartData(
+          tickers,
+          undefined,
+          range
+        );
 
         benchmarkData.value = tickers.map(
           (ticker) => chartQuotesResponse[ticker]
@@ -48,8 +59,23 @@ export default defineComponent({
       });
     };
 
+    const setBenchmarkData = async (tickers: string[]) => {
+      selectedTickers.value = tickers;
+      await fetchBenchmarkData(tickers, currentApiRange.value);
+    };
+
+    const onApiRangeChange = async (range?: string) => {
+      if (range === currentApiRange.value) return;
+      currentApiRange.value = range;
+
+      if (selectedTickers.value.length > 0) {
+        await fetchBenchmarkData(selectedTickers.value, range);
+      }
+    };
+
     return {
       setBenchmarkData,
+      onApiRangeChange,
       benchmarkData,
       benchmarkOptions,
     };

--- a/src/components/analytics/PortfolioPerformance.vue
+++ b/src/components/analytics/PortfolioPerformance.vue
@@ -162,7 +162,8 @@ export default defineComponent({
       default: [] as StockCharData[],
     },
   },
-  setup(props) {
+  emits: ['update:apiRange'],
+  setup(props, { emit }) {
     const showResetZoom = ref(false);
     const chartRef: Ref = ref(undefined);
     const selectedTimeRangeOption = ref<Option>(timeRangeOptions[2]);
@@ -228,6 +229,11 @@ export default defineComponent({
       selectedTimeRangeOption.value =
         timeRangeOptions.find((option) => option.value === range.value) ??
         timeRangeOptions[0];
+
+      emit(
+        'update:apiRange',
+        (selectedTimeRangeOption.value.apiRange as string) ?? undefined
+      );
     };
 
     const timeRangeText = computed(() => {

--- a/src/components/analytics/constants.ts
+++ b/src/components/analytics/constants.ts
@@ -21,5 +21,5 @@ export const timeRangeOptions: Option[] = [
   { label: '6m', value: '6m', days: 180 },
   { label: 'YTD', value: 'ytd', days: yearToDateDays() },
   { label: '1y', value: '1y', days: 365 },
-  { label: '5y', value: '5y', days: 365 * 5 },
+  { label: '5y', value: '5y', days: 365 * 5, apiRange: '5y' },
 ];


### PR DESCRIPTION
## Summary
- Analytics charts crashed when selecting 5Y because benchmark data was hardcoded to fetch only 1 year from the Yahoo Finance API
- Now passes the extended API range (`5y`) through to `getQuotesChartData` only when a period beyond 1 year is selected
- Periods <= 1 year continue using the default 1y fetch — no unnecessary re-fetches

## Changes
- `constants.ts` — added `apiRange: '5y'` to the 5Y time range option
- `PortfolioPerformance.vue` — emits `update:apiRange` when time range selection changes
- `AnalyticsGraphs.vue` — tracks selected tickers and API range, re-fetches benchmark data when range changes beyond 1y

## Test Plan
- [ ] Navigate to `/analytics`
- [ ] Select **5Y** period on either chart — should render benchmark data without crashing
- [ ] Select **1Y** or shorter period — should use default fetch, no extra API call
- [ ] Switch benchmarks (SPY, QQQ, etc.) while on 5Y — should fetch with extended range

🤖 Generated with [Claude Code](https://claude.com/claude-code)