### PR TITLE
fix: allocate sell shares when transaction has no holdingId yet

### DIFF
--- a/src/service/transactions.ts
+++ b/src/service/transactions.ts
@@ -55,7 +55,9 @@ const api = {
         (t) =>
           transactionsTransformer.isBuy(t) &&
           t.ticker === transaction.ticker &&
-          (!t.holdingId || t.holdingId === transaction.holdingId)
+          (!t.holdingId ||
+            !transaction.holdingId ||
+            t.holdingId === transaction.holdingId)
       );
 
     let remainingShares = transaction.actualShares;


### PR DESCRIPTION
## Summary

Fixes a bug where a freshly added Sell transaction would render `---` for profit and not increase free cashflow, even though buy positions clearly existed for the ticker.

## Root cause

`transactionsStore.add()` calls `allocateSellTransaction` *before* the holdings store's `$onAction` listener assigns `transaction.holdingId` (that happens in a `context.after` callback that runs after the action returns).

Once existing buy transactions have been synced at least once, they carry a `holdingId`. The filter introduced in PR #58:

```ts
(!t.holdingId || t.holdingId === transaction.holdingId)
```

then evaluates to `false` for every buy when the new sell's `holdingId` is `undefined` — so `available` is empty, the FIFO loop never runs, and the sell is persisted with `realizedProfit = 0` and `paidPrice = 0`.

Downstream effects:

- **Profit `---`**: `balanceMap` returns `realizedProfit || 0` for sells → `profit.value` falsy → `TransactionsTable` falls back to `---`.
- **Cashflow unchanged**: `paidPrice = 0` means `fundsValue = paidPrice ?? totalValue` resolves to `0` (nullish coalescing keeps the `0`), so `holding.invested` doesn't decrease and `cashFlow = deposits + realized − invested` stays put.

## Fix

Loosen the filter so it also passes when the incoming sell has no `holdingId` yet — mirroring the relaxed match already used in `syncHoldingWithTransactions` (`src/service/holdings.ts:52`):

```ts
(!t.holdingId || !transaction.holdingId || t.holdingId === transaction.holdingId)
```

Minimal change, no architectural reshuffle. The deeper ordering issue (allocation running before `holdingId` is known) is left for a follow-up.

## Recovery for already-broken transactions

Re-saving an affected sell from the edit dialog will re-run allocation with the now-permissive filter and correctly populate `realizedProfit` / `paidPrice`; the holding sync will then fix `invested` and cashflow.

## Test plan

- [ ] Add a new Sell transaction on a holding that already has synced buys → profit column shows realized P&L (not `---`)
- [ ] Free cashflow KPI on the dashboard increases by the FIFO-allocated cost basis amount
- [ ] Buy rows show updated `actualShares` annotation (e.g. `30 | 10A`) reflecting the allocation
- [ ] Existing 01/20/26-style sells still display correctly (regression check)
- [ ] Removing a sell still restores `actualShares` on its source buys

🤖 Generated with [Claude Code](https://claude.com/claude-code)