### PR TITLE
fix: analytics chart crash on chart range beyond 1y

### DIFF
--- a/src/components/analytics/AnalyticsGraphs.vue
+++ b/src/components/analytics/AnalyticsGraphs.vue
@@ -5,12 +5,14 @@
     :title="$t('charts.portfolio_value')"
     :show-transactions-markers="true"
     :benchmarkData="benchmarkData"
+    @update:apiRange="onApiRangeChange"
   />
 
   <portfolio-performance
     :title="$t('charts.portfolio_performance')"
     mode="percentage"
     :benchmarkData="benchmarkData"
+    @update:apiRange="onApiRangeChange"
   />
 
   <portfolio-monthly-yield :benchmark-data="benchmarkData" />
@@ -35,12 +37,21 @@ export default defineComponent({
   },
   setup() {
     const benchmarkData = ref<StockCharData[]>([]);
+    const selectedTickers = ref<string[]>([]);
+    const currentApiRange = ref<string | undefined>(undefined);
 
     const { emitLoadingTask } = useLoadingStore();
 
-    const setBenchmarkData = async (tickers: string[]) => {
+    const fetchBenchmarkData = async (
+      tickers: string[],
+      range?: string
+    ) => {
       await emitLoadingTask(async () => {
-        const chartQuotesResponse = await getQuotesChartData(tickers);
+        const chartQuotesResponse = await getQuotesChartData(
+          tickers,
+          undefined,
+          range
+        );
 
         benchmarkData.value = tickers.map(
           (ticker) => chartQuotesResponse[ticker]
@@ -48,8 +59,23 @@ export default defineComponent({
       });
     };
 
+    const setBenchmarkData = async (tickers: string[]) => {
+      selectedTickers.value = tickers;
+      await fetchBenchmarkData(tickers, currentApiRange.value);
+    };
+
+    const onApiRangeChange = async (range?: string) => {
+      if (range === currentApiRange.value) return;
+      currentApiRange.value = range;
+
+      if (selectedTickers.value.length > 0) {
+        await fetchBenchmarkData(selectedTickers.value, range);
+      }
+    };
+
     return {
       setBenchmarkData,
+      onApiRangeChange,
       benchmarkData,
       benchmarkOptions,
     };

--- a/src/components/analytics/PortfolioPerformance.vue
+++ b/src/components/analytics/PortfolioPerformance.vue
@@ -162,7 +162,8 @@ export default defineComponent({
       default: [] as StockCharData[],
     },
   },
-  setup(props) {
+  emits: ['update:apiRange'],
+  setup(props, { emit }) {
     const showResetZoom = ref(false);
     const chartRef: Ref = ref(undefined);
     const selectedTimeRangeOption = ref<Option>(timeRangeOptions[2]);
@@ -228,6 +229,11 @@ export default defineComponent({
       selectedTimeRangeOption.value =
         timeRangeOptions.find((option) => option.value === range.value) ??
         timeRangeOptions[0];
+
+      emit(
+        'update:apiRange',
+        (selectedTimeRangeOption.value.apiRange as string) ?? undefined
+      );
     };
 
     const timeRangeText = computed(() => {

--- a/src/components/analytics/constants.ts
+++ b/src/components/analytics/constants.ts
@@ -21,5 +21,5 @@ export const timeRangeOptions: Option[] = [
   { label: '6m', value: '6m', days: 180 },
   { label: 'YTD', value: 'ytd', days: yearToDateDays() },
   { label: '1y', value: '1y', days: 365 },
-  { label: '5y', value: '5y', days: 365 * 5 },
+  { label: '5y', value: '5y', days: 365 * 5, apiRange: '5y' },
 ];

--- a/src/service/charts/portfolioPerformance.ts
+++ b/src/service/charts/portfolioPerformance.ts
@@ -106,6 +106,31 @@ const normalizeBenchmarkValue = (
   return series;
 };
 
+/**
+ * Aligns portfolio history items to a period time range, forward-filling
+ * dates that have no matching history entry with the most recent known item.
+ * Guarantees output length === periodTimeRange.length so callers can index
+ * positionally alongside a benchmark series normalized to the same range.
+ */
+const alignHistoryToPeriod = (
+  portfolioHistory: PortfolioHistory[],
+  periodTimeRange: number[]
+): PortfolioHistory[] => {
+  const byDate = new Map<number, PortfolioHistory>();
+  portfolioHistory.forEach((history) => {
+    byDate.set(midDay(new Date(history.date)).getTime(), history);
+  });
+
+  let lastKnown = portfolioHistory[0];
+  return periodTimeRange.map((date) => {
+    const match = byDate.get(date);
+    if (match) {
+      lastKnown = match;
+    }
+    return lastKnown;
+  });
+};
+
 const normalizePerformanceData = (
   portfolioHistory: PortfolioHistory[],
   benchmarks: StockCharData[],
@@ -119,6 +144,8 @@ const normalizePerformanceData = (
   if (!periodHistoryItems.length) {
     return [];
   }
+
+  const alignedHistory = alignHistoryToPeriod(periodHistoryItems, periodTimeRange);
 
   const portfolioHistorySeries = normalizeSeriesTimePeriod(
     {
@@ -150,7 +177,7 @@ const normalizePerformanceData = (
     })
     .filter((series) => series.data.length > 1)
     .map((series) => normalizeSeriesTimePeriod(series, periodTimeRange))
-    .map((series) => normalizeBenchmarkValue(series, periodHistoryItems, mode));
+    .map((series) => normalizeBenchmarkValue(series, alignedHistory, mode));
 
   // Ensuring each series includes data point for each day in the period time.
   return [portfolioHistorySeries, ...benchmarksSeries];


### PR DESCRIPTION
## Summary
- Analytics tab crashed with `Cannot read properties of undefined (reading 'invested')` (and the cascading `translate(NaN, …)` / `<svg height="NaN">` apexcharts warnings).
- Root cause: `normalizeBenchmarkValue` indexed `portfolioHistory` positionally against a benchmark series normalized to `periodTimeRange.length`. When portfolio history dates didn't perfectly cover every entry in `periodTimeRange` (missed daily snapshot, DST-shifted midDay timestamp, etc.) `portfolioHistory[index]` was `undefined`. The recent extended-benchmark fix (c0059c9) made this much easier to trigger because 5y benchmark data stretches the period over a longer window.
- Fix: forward-fill portfolio history into a new array aligned to `periodTimeRange` before benchmark normalization, so positional access is safe regardless of gaps.
- Also bundles the prior commit on this branch (extended benchmark fetch beyond 1y).

## Test plan
- [ ] Open `/analytics` on prod after deploy — chart renders without console errors
- [ ] Switch through 7d / 1m / 3m / 6m / YTD / 1y / 5y — each renders, benchmark series aligns with portfolio
- [ ] Verify percentage mode chart also renders correctly across all ranges

🤖 Generated with [Claude Code](https://claude.com/claude-code)