### PR TITLE
fix: heatmap loss positions shown as gains (double-negation)

### DIFF
--- a/src/service/charts/portfolioHeatMap.ts
+++ b/src/service/charts/portfolioHeatMap.ts
@@ -11,8 +11,7 @@ export const getPortfolioHoldingsHeatMapChartOptions = (
   const series = [
     {
       data: holdingsStore.portfolioHoldings.map((holding) => {
-        const normalizedProfitPercent =
-          holding.profit.percent * (holding.profit.value >= 0 ? 1 : -1) * 100;
+        const normalizedProfitPercent = holding.profit.percent * 100;
 
         return {
           x: holding.ticker,


### PR DESCRIPTION
## Summary
- `profit.percent` is already a signed value (`profitValue / holding.invested` — negative for losses)
- Previous formula applied an extra `* -1` for losses, double-negating them: a -15% loss became +15% and rendered green
- Fix: remove the sign-flip; just multiply by 100 to convert the fraction to a percentage

## Root cause
```ts
// Before (buggy): double-negates losses
holding.profit.percent * (holding.profit.value >= 0 ? 1 : -1) * 100

// After: profit.percent is already signed
holding.profit.percent * 100
```

## Test plan
- [ ] Open dashboard with a portfolio that has loss positions
- [ ] Verify loss positions show red tiles in the heatmap (not green)
- [ ] Verify gain positions still show green/teal tiles
- [ ] Verify tooltip still shows correct signed percentage + currency value

🤖 Generated with [Claude Code](https://claude.com/claude-code)