### PR TITLE
fix: realized gains tooltip shows literal placeholder instead of value

### DIFF
--- a/src/components/common/ProfitIndicator.vue
+++ b/src/components/common/ProfitIndicator.vue
@@ -8,7 +8,7 @@
         <q-tooltip class="text-caption">
           {{
             $t('realized_gains_tooltip', {
-              realized: $n(realizedValue, 'decimal'),
+              realizedValue: $n(realizedValue, 'decimal'),
             })
           }}
         </q-tooltip>

--- a/src/i18n/en-US/translations.ts
+++ b/src/i18n/en-US/translations.ts
@@ -20,7 +20,7 @@ export const enUsMessages = {
   capital: 'Capital gains',
   by_invested: 'By Invested',
   by_sector: 'By Sector',
-  realized_gains_tooltip: 'Realized gains from sold shares: +{realized}',
+  realized_gains_tooltip: 'Realized gains from sold shares: +{realizedValue}',
   portfolios: {
     title: "Manage portfolio's",
     create: 'New Portfolio',


### PR DESCRIPTION
## Summary
- Holdings table profit column tooltip shows `{realized}` literally instead of the formatted dollar amount
- Root cause: i18n interpolation placeholder `{realized}` collides with sibling message key `realized: 'Realized gains'` in the same translations object, preventing vue-i18n from interpolating the named parameter
- Fix: rename placeholder to `{realizedValue}` in both the i18n key and the component

## Test plan
- [ ] Open `/holdings` with a position that has realized profits (sold shares)
- [ ] Hover over the profit column — tooltip should show e.g. "Realized gains from sold shares: +$123.45"
- [ ] Verify no literal `{realizedValue}` text appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)